### PR TITLE
Kicad cli

### DIFF
--- a/.github/workflows/kicad.yml
+++ b/.github/workflows/kicad.yml
@@ -7,114 +7,125 @@ on:
     branches: [ "main", "kicad-cli" ]
 
 jobs:
-  # fmc_lpc_template.kicad_pcb: failed to load with pcbnew, aborting :(
-  # kicad5-test:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ghcr.io/inti-cmnb/kicad5_auto
-  #     options: --user root
+  kicad5-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/inti-cmnb/kicad5_auto
+      options: --user root
 
-  #   steps:
-  #   - name: clone
-  #     uses: actions/checkout@v3
+    steps:
+    - name: clone
+      uses: actions/checkout@v3
 
-  #   - name: setup_kiff
-  #     run: |
-  #       apt update -y
-  #       apt install -y unzip
-  #       unzip test.zip
+    - name: setup_kiff
+      run: |
+        apt update -y
+        apt install -y unzip poppler-utils pipx
+        pipx install .
+        unzip test.zip
 
-  #   - name: run_kiff
-  #     working-directory: test/
-  #     run: |
-  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+    - name: run_kiff
+      working-directory: test/
+      run: |
+          export PATH=$PATH:$HOME/.local/bin
+          export PYTHONPATH=/usr/lib/python3/dist-packages
+          kiff -c "HEAD~1" test5.kicad_pcb
 
-  #   - name: archive_results
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: kicad5_diffs
-  #       path: test/diffs/
+    - name: archive_results
+      uses: actions/upload-artifact@v4
+      with:
+        name: kicad5_diffs
+        path: test/diffs/
 
-  # kicad6-test:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ghcr.io/inti-cmnb/kicad6_auto
-  #     options: --user root
+  kicad6-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/inti-cmnb/kicad6_auto
+      options: --user root
 
-  #   steps:
-  #   - name: clone
-  #     uses: actions/checkout@v3
+    steps:
+    - name: clone
+      uses: actions/checkout@v3
 
-  #   - name: setup_kiff
-  #     run: |
-  #       apt update -y
-  #       apt install -y unzip
-  #       unzip test.zip
+    - name: setup_kiff
+      run: |
+        apt update -y
+        apt install -y unzip poppler-utils pipx
+        pipx install .
+        unzip test.zip
 
-  #   - name: run_kiff
-  #     working-directory: test/
-  #     run: |
-  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+    - name: run_kiff
+      working-directory: test/
+      run: |
+          export PATH=$PATH:$HOME/.local/bin
+          export PYTHONPATH=/usr/lib/python3/dist-packages
+          kiff -c "HEAD~1" test5.kicad_pcb
 
-  #   - name: archive_results
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: kicad6_diffs
-  #       path: test/diffs/
+    - name: archive_results
+      uses: actions/upload-artifact@v4
+      with:
+        name: kicad6_diffs
+        path: test/diffs/
 
-  # kicad7-test:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: kicad/kicad:7.0.10
-  #     options: --user root
+  kicad7-test:
+    runs-on: ubuntu-latest
+    container:
+      image: kicad/kicad:7.0.10
+      options: --user root
 
-  #   steps:
-  #   - name: clone
-  #     uses: actions/checkout@v3
+    steps:
+    - name: clone
+      uses: actions/checkout@v3
 
-  #   - name: setup_kiff
-  #     run: |
-  #       apt update -y
-  #       apt install -y poppler-utils
-  #       unzip test.zip
+    - name: setup_kiff
+      run: |
+        apt update -y
+        apt install -y poppler-utils pipx
+        pipx install .
+        unzip test.zip
 
-  #   - name: run_kiff
-  #     working-directory: test/
-  #     run: |
-  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+    - name: run_kiff
+      working-directory: test/
+      run: |
+          export PATH=$PATH:$HOME/.local/bin
+          export PYTHONPATH=/usr/lib/python3/dist-packages
+          kiff -c "HEAD~1" test5.kicad_pcb
 
-  #   - name: archive_results
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: kicad7_diffs
-  #       path: test/diffs/
+    - name: archive_results
+      uses: actions/upload-artifact@v4
+      with:
+        name: kicad7_diffs
+        path: test/diffs/
 
-  # kicad8-test:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: kicad/kicad:8.0.5
-  #     options: --user root
+  kicad8-test:
+    runs-on: ubuntu-latest
+    container:
+      image: kicad/kicad:8.0.5
+      options: --user root
 
-  #   steps:
-  #   - name: clone
-  #     uses: actions/checkout@v3
+    steps:
+    - name: clone
+      uses: actions/checkout@v3
 
-  #   - name: setup_kiff
-  #     run: |
-  #       apt update -y
-  #       apt install -y poppler-utils
-  #       unzip test.zip
+    - name: setup_kiff
+      run: |
+        apt update -y
+        apt install -y poppler-utils pipx
+        pipx install .
+        unzip test.zip
 
-  #   - name: run_kiff
-  #     working-directory: test/
-  #     run: |
-  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+    - name: run_kiff
+      working-directory: test/
+      run: |
+          export PATH=$PATH:$HOME/.local/bin
+          export PYTHONPATH=/usr/lib/python3/dist-packages
+          kiff -c "HEAD~1" test5.kicad_pcb
 
-  #   - name: archive_results
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: kicad8_diffs
-  #       path: test/diffs/
+    - name: archive_results
+      uses: actions/upload-artifact@v4
+      with:
+        name: kicad8_diffs
+        path: test/diffs/
 
 
   kicad9-test:
@@ -138,6 +149,7 @@ jobs:
       working-directory: test/
       run: |
           export PATH=$PATH:$HOME/.local/bin
+          export PYTHONPATH=/usr/lib/python3/dist-packages
           kiff -c "HEAD~1" test5.kicad_pcb
 
     - name: archive_results

--- a/.github/workflows/kicad.yml
+++ b/.github/workflows/kicad.yml
@@ -8,10 +8,119 @@ on:
 
 jobs:
   # fmc_lpc_template.kicad_pcb: failed to load with pcbnew, aborting :(
-  kicad5-test:
+  # kicad5-test:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ghcr.io/inti-cmnb/kicad5_auto
+  #     options: --user root
+
+  #   steps:
+  #   - name: clone
+  #     uses: actions/checkout@v3
+
+  #   - name: setup_kiff
+  #     run: |
+  #       apt update -y
+  #       apt install -y unzip
+  #       unzip test.zip
+
+  #   - name: run_kiff
+  #     working-directory: test/
+  #     run: |
+  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+
+  #   - name: archive_results
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: kicad5_diffs
+  #       path: test/diffs/
+
+  # kicad6-test:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ghcr.io/inti-cmnb/kicad6_auto
+  #     options: --user root
+
+  #   steps:
+  #   - name: clone
+  #     uses: actions/checkout@v3
+
+  #   - name: setup_kiff
+  #     run: |
+  #       apt update -y
+  #       apt install -y unzip
+  #       unzip test.zip
+
+  #   - name: run_kiff
+  #     working-directory: test/
+  #     run: |
+  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+
+  #   - name: archive_results
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: kicad6_diffs
+  #       path: test/diffs/
+
+  # kicad7-test:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: kicad/kicad:7.0.10
+  #     options: --user root
+
+  #   steps:
+  #   - name: clone
+  #     uses: actions/checkout@v3
+
+  #   - name: setup_kiff
+  #     run: |
+  #       apt update -y
+  #       apt install -y poppler-utils
+  #       unzip test.zip
+
+  #   - name: run_kiff
+  #     working-directory: test/
+  #     run: |
+  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+
+  #   - name: archive_results
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: kicad7_diffs
+  #       path: test/diffs/
+
+  # kicad8-test:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: kicad/kicad:8.0.5
+  #     options: --user root
+
+  #   steps:
+  #   - name: clone
+  #     uses: actions/checkout@v3
+
+  #   - name: setup_kiff
+  #     run: |
+  #       apt update -y
+  #       apt install -y poppler-utils
+  #       unzip test.zip
+
+  #   - name: run_kiff
+  #     working-directory: test/
+  #     run: |
+  #         python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+
+  #   - name: archive_results
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: kicad8_diffs
+  #       path: test/diffs/
+
+
+  kicad9-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/inti-cmnb/kicad5_auto
+      image: kicad/kicad:9.0
       options: --user root
 
     steps:
@@ -21,97 +130,18 @@ jobs:
     - name: setup_kiff
       run: |
         apt update -y
-        apt install -y unzip
+        apt install -y poppler-utils pipx
+        pipx install .
         unzip test.zip
 
     - name: run_kiff
       working-directory: test/
       run: |
-          python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
+          export PATH=$PATH:/root/.local/bin
+          kiff -c "HEAD~1" test5.kicad_pcb
 
     - name: archive_results
       uses: actions/upload-artifact@v4
       with:
-        name: kicad5_diffs
-        path: test/diffs/
-
-  kicad6-test:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/inti-cmnb/kicad6_auto
-      options: --user root
-
-    steps:
-    - name: clone
-      uses: actions/checkout@v3
-
-    - name: setup_kiff
-      run: |
-        apt update -y
-        apt install -y unzip
-        unzip test.zip
-
-    - name: run_kiff
-      working-directory: test/
-      run: |
-          python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
-
-    - name: archive_results
-      uses: actions/upload-artifact@v4
-      with:
-        name: kicad6_diffs
-        path: test/diffs/
-
-  kicad7-test:
-    runs-on: ubuntu-latest
-    container:
-      image: kicad/kicad:7.0.10
-      options: --user root
-
-    steps:
-    - name: clone
-      uses: actions/checkout@v3
-
-    - name: setup_kiff
-      run: |
-        apt update -y
-        apt install -y poppler-utils
-        unzip test.zip
-
-    - name: run_kiff
-      working-directory: test/
-      run: |
-          python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
-
-    - name: archive_results
-      uses: actions/upload-artifact@v4
-      with:
-        name: kicad7_diffs
-        path: test/diffs/
-
-  kicad8-test:
-    runs-on: ubuntu-latest
-    container:
-      image: kicad/kicad:8.0.5
-      options: --user root
-
-    steps:
-    - name: clone
-      uses: actions/checkout@v3
-
-    - name: setup_kiff
-      run: |
-        apt update -y
-        apt install -y poppler-utils
-        unzip test.zip
-
-    - name: run_kiff
-      working-directory: test/
-      run: |
-          python3 ../kiff.py -c "HEAD~1" test5.kicad_pcb
-
-    - name: archive_results
-      uses: actions/upload-artifact@v4
-      with:
-        name: kicad8_diffs
+        name: kicad9_diffs
         path: test/diffs/

--- a/.github/workflows/kicad.yml
+++ b/.github/workflows/kicad.yml
@@ -118,7 +118,6 @@ jobs:
       working-directory: test/
       run: |
           export PATH=$PATH:$HOME/.local/bin
-          export PYTHONPATH=/usr/lib/python3/dist-packages
           kiff -c "HEAD~1" test5.kicad_pcb
 
     - name: archive_results
@@ -149,7 +148,6 @@ jobs:
       working-directory: test/
       run: |
           export PATH=$PATH:$HOME/.local/bin
-          export PYTHONPATH=/usr/lib/python3/dist-packages
           kiff -c "HEAD~1" test5.kicad_pcb
 
     - name: archive_results

--- a/.github/workflows/kicad.yml
+++ b/.github/workflows/kicad.yml
@@ -2,9 +2,9 @@ name: Kicad CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "kicad-cli" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "kicad-cli" ]
 
 jobs:
   # fmc_lpc_template.kicad_pcb: failed to load with pcbnew, aborting :(

--- a/.github/workflows/kicad.yml
+++ b/.github/workflows/kicad.yml
@@ -137,7 +137,7 @@ jobs:
     - name: run_kiff
       working-directory: test/
       run: |
-          export PATH=$PATH:/root/.local/bin
+          export PATH=$PATH:$HOME/.local/bin
           kiff -c "HEAD~1" test5.kicad_pcb
 
     - name: archive_results

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+test/
+*.egg-info/
+build/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ kiff test5.kicad_pcb -c HEAD~1
 ```
 
 # Supported Kicad versions
-There are currently CI tests in place for versions 5.1.9, 6.0.11, 7.0.10, and 8.0.5. If the below badge is green, they've all succeeded.
+There are currently CI tests in place for versions 5.1.9, 6.0.11, 7.0.10, 8.0.5 and 9.0.0. If the below badge is green, they've all succeeded.
 
 [![CI status](https://github.com/michael-betz/kiff/actions/workflows/kicad.yml/badge.svg)](https://github.com/michael-betz/kiff/actions/workflows/kicad.yml)
 

--- a/README.md
+++ b/README.md
@@ -14,24 +14,61 @@ Elements which have been added in the local version are colored green,
 removed ones red.
 Note that this may look inverted for features on copper fills.
 
-# Requires
-  * `poppler-utils` to convert the Kicad .pdf plots to bitmaps
-  * `python-pil` and `python-numpy` for image manipulations
-  * `kiff.py` needs to be in your python path
+# Installation (Debian Bullseye and newer)
+At least python version 3.11 (to be verified) is required.
+
+```bash
+# Install dependencies
+# poppler-utils is used to convert the Kicad .pdf plots to bitmaps
+sudo apt install poppler-utils pipx
+
+# Install kiff
+pipx install git+https://github.com/michael-betz/kiff.git
+
+# Give kiff a test-run
+wget https://github.com/michael-betz/kiff/raw/refs/heads/main/test.zip
+unzip test.zip
+cd test/
+kiff test5.kicad_pcb -c HEAD~1
+```
 
 # Supported Kicad versions
 There are currently CI tests in place for versions 5.1.9, 6.0.11, 7.0.10, and 8.0.5. If the below badge is green, they've all succeeded.
 
 [![CI status](https://github.com/michael-betz/kiff/actions/workflows/kicad.yml/badge.svg)](https://github.com/michael-betz/kiff/actions/workflows/kicad.yml)
 
-Earlier versions were also tested to work with Python 2 and 3. To enable scripting with Python 3, Kicad needs to be compiled with `-DKICAD_SCRIPTING_PYTHON3=TRUE`.
+By default, the legacy python API is used to generate the .pdfs. The API needs to be installed in your python path (`import pcbnew` must work). This API will be no more available in Kicad 9.
+
+If the legacy API fails, kiff falls back on the `kicad-cli` command-line tool, which can also plot the .pdfs. This tool has been introduced in version 7.
+
+kiff will try to run `kicad-cli` natively (make sure it is in your path). If that fails, it will try to run it in the flatpak container (assuming kicad was installed through flatpak).
+
+Note that `kicad-cli`-mode still has some caveats. It does not support refreshing the copper-zone fills before diffing. Also it does not crop the image to the PCB size.
 
 # Usage example
 Compare the current version against the one from 3 commits ago:
 
 ```bash
 $ cd <kicad_project>
-$ kiff.py my_pcb.kicad_pcb -c HEAD~3
+$ kiff my_pcb.kicad_pcb -c HEAD~3
+
+WARNING: couldn't find pcbnew legacy python API, using kicad-cli for pdf-exports
+layers: F.Cu B.Cu F.SilkS B.SilkS
+> plot_24eb330
+found kicad-cli version: 9.0.0
+WARNING: automatic zone-refills are not supported (yet)
+$ flatpak run --command=kicad-cli org.kicad.KiCad pcb export pdf -l F.Cu,B.Cu,F.SilkS,B.SilkS --black-and-white test5.kicad_pcb --mode-separate -o plot_24eb330
+$ git checkout HEAD~1
+> plot_c8fa4b6
+$ flatpak run --command=kicad-cli org.kicad.KiCad pcb export pdf -l F.Cu,B.Cu,F.SilkS,B.SilkS --black-and-white test5.kicad_pcb --mode-separate -o plot_c8fa4b6
+$ git checkout -
+Previous HEAD position was c8fa4b6 initial version done in kicad 5.1.2
+Switched to branch 'main'
+> diffs/F.Cu.png     (+0.000390, -0.001082)
+> diffs/B.Cu.png     (+0.001569, -0.000358)
+> diffs/F.SilkS.png  (+0.000000, -0.000018)
+> diffs/B.SilkS.png  (+0.000000, -0.000000)
+Removing temporary directories
 ```
 
 This will generate `diffs/<layer_name>.png` for each layer.

--- a/kiff/kiff.py
+++ b/kiff/kiff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # tested on Python 2 & Python 3
-'''
+"""
 Kiff, the Kicad Diff!
 
 Graphically compare layout changes between two git versions of a PCB.
@@ -17,24 +17,23 @@ A useful shortcut for the commit-id is `HEAD~1`, which means the previous one.
 Elements which have been added in the local version are colored green,
 removed ones red.
 Note that this may look inverted for features on copper fills.
-'''
+"""
 import argparse
 from PIL import Image
 from numpy import array, zeros, uint8, sum
-from subprocess import call, check_output
+from subprocess import check_output
 from io import BytesIO
 from os.path import splitext, join
 from os import mkdir
 from shutil import rmtree
-from plot_layers import plot_layers
 
 
 def img_diff(i1, i2, doInvert=True):
-    '''
+    """
     i1, i2: PIL Image objects of same size to compare
     doInvert: set true when input is black on white background
     returns: PIL Image of the diff
-    '''
+    """
     a0 = array(i1)
     a1 = array(i2)
     if doInvert:
@@ -50,7 +49,7 @@ def img_diff(i1, i2, doInvert=True):
     # assign results to color channels
     a_out[:, :, 0] = common * 0.2 + diff1 * 0.8  # Red
     a_out[:, :, 1] = common * 0.2 + diff2 * 0.8  # Green
-    a_out[:, :, 2] = common * 0.2                # Blue
+    a_out[:, :, 2] = common * 0.2  # Blue
 
     # how many pixels changed in the whole image: 1.0 = all pixels changed
     sum_all = a0.shape[0] * a0.shape[1] * 255
@@ -60,85 +59,84 @@ def img_diff(i1, i2, doInvert=True):
     return Image.fromarray(a_out), added, removed
 
 
-def load_pdf(fName, x=4.7, y=2.6, W=7.3, H=6.0, r=600):
-    '''
+def load_pdf(fName, bounds=None, r=600):
+    """
     fName: .pdf file to load
-    x, y, W, H: crop window [inch]
+    bounds: optional crop window [inch]. Like {x=4.7, y=2.6, W=7.3, H=6.0}
     r: resolution [dpi]
     returns: PIL Image
-    '''
-    ppm_str = check_output([
-        'pdftoppm',
-        '-r', str(int(r)),
-        '-x', str(int(x * r)),
-        '-y', str(int(y * r)),
-        '-W', str(int(W * r)),
-        '-H', str(int(H * r)),
-        fName
-    ])
-    return Image.open(BytesIO(ppm_str)).convert('L')
+    """
+    cmd = ["pdftoppm", "-r", str(int(r))]
+    if bounds:
+        cmd += [
+            "-x",
+            str(int(bounds["x"] * r)),
+            "-y",
+            str(int(bounds["y"] * r)),
+            "-W",
+            str(int(bounds["W"] * r)),
+            "-H",
+            str(int(bounds["H"] * r)),
+        ]
+    cmd += [fName]
+    ppm_str = check_output(cmd)
+    return Image.open(BytesIO(ppm_str)).convert("L")
 
 
 def desc():
-    ''' the git describe string '''
-    tmp = check_output(['git', 'describe', '--dirty', '--always'])
-    return tmp.decode('ascii').strip()
+    """the git describe string"""
+    tmp = check_output(["git", "describe", "--dirty", "--always"])
+    return tmp.decode("ascii").strip()
 
 
 def co(cmds):
-    ''' run and print cmds, raises exception if command returns != 0 '''
-    print('$ ' + ' '.join(cmds))
+    """run and print cmds, raises exception if command returns != 0"""
+    print("$ " + " ".join(cmds))
     check_output(cmds)
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("kicad_pcb", help="the `.kicad_pcb` file to DIFF")
+    parser.add_argument(
+        "-c", "--commit", default="HEAD", help="git commit-id to compare current version against. Default: HEAD"
     )
     parser.add_argument(
-        'kicad_pcb',
-        help='the `.kicad_pcb` file to DIFF'
+        "-l", "--layers", default=0, type=int, help="Number of inner layers (InX.Cu) to plot. Default: 0"
     )
     parser.add_argument(
-        '-c', '--commit',
-        default='HEAD',
-        help='git commit-id to compare current version against. Default: HEAD'
-    )
-    parser.add_argument(
-        '-l', '--layers',
-        default=0,
-        type=int,
-        help='Number of inner layers (InX.Cu) to plot. Default: 0'
-    )
-    parser.add_argument(
-        '-ll', '--layer-list',
-        default='F.Cu B.Cu F.SilkS B.SilkS',
+        "-ll",
+        "--layer-list",
+        default="F.Cu B.Cu F.SilkS B.SilkS",
         type=str,
-        help='Space separated list of layer names to plot. Default: F.Cu B.Cu F.SilkS B.SilkS'
+        help="Space separated list of layer names to plot. Default: F.Cu B.Cu F.SilkS B.SilkS",
     )
+    parser.add_argument("-r", "--resolution", default=400, type=int, help="Plotting resolution in [dpi]. Default: 400")
+    parser.add_argument("-k", "--keep", action="store_true", help="Don`t delete temporary .pdf layer plots")
     parser.add_argument(
-        '-r', '--resolution',
-        default=400,
-        type=int,
-        help='Plotting resolution in [dpi]. Default: 400'
-    )
-    parser.add_argument(
-        '-k', '--keep',
-        action='store_true',
-        help='Don`t delete temporary .pdf layer plots'
+        "--cli", action="store_true", help="Use kicad-cli instead of the legacy python API for .pdf layer plots"
     )
     args = parser.parse_args()
 
+    if args.cli:
+        from plot_layers_cli import plot_layers
+    else:
+        try:
+            from kiff.plot_layers import plot_layers
+        except ModuleNotFoundError:
+            print("WARNING: couldn't find pcbnew legacy python API, using kicad-cli for pdf-exports")
+            from kiff.plot_layers_cli import plot_layers
+
     layers = args.layer_list.split()
-    layers += ['In{}.Cu'.format(i + 1) for i in range(args.layers)]
-    print('layers: ' + ' '.join(layers))
+    layers += ["In{}.Cu".format(i + 1) for i in range(args.layers)]
+    print("layers: " + " ".join(layers))
 
     # Check for local (un-commited) changes
     # https://stackoverflow.com/questions/5143795/how-can-i-check-in-a-bash-script-if-my-local-git-repository-has-changes
-    do_stash = check_output(['git', 'status', '--porcelain', '--untracked-files=no']) != b''
+    do_stash = check_output(["git", "status", "--porcelain", "--untracked-files=no"]) != b""
 
-    if not do_stash and args.commit == 'HEAD':
-        print('No local changes, nothing to compare. Try -c <commit-id>')
+    if not do_stash and args.commit == "HEAD":
+        print("No local changes, nothing to compare. Try -c <commit-id>")
         return -1
 
     # output directory name is derived from `git describe`
@@ -150,64 +148,60 @@ def main():
         exit(1)
 
     # Do a .pdf plot of the current version
-    dir1 = 'plot_' + git1_name
-    print('> ' + dir1)
+    dir1 = "plot_" + git1_name
+    print("> " + dir1)
     bounds1 = plot_layers(args.kicad_pcb, dir1, layers)
-    if bounds1 is None:
-        exit(1)
 
     # Stash local changes if needed
     if do_stash:
-        co(['git', 'stash'])
+        co(["git", "stash"])
 
     # checkout specified git version (default: HEAD) ...
-    if args.commit != 'HEAD':
-        co(['git', 'checkout', args.commit])
+    if args.commit != "HEAD":
+        co(["git", "checkout", args.commit])
 
     # ... and do a .pdf plot of it
-    dir2 = 'plot_' + desc()
-    print('> ' + dir2)
+    dir2 = "plot_" + desc()
+    print("> " + dir2)
     bounds2 = plot_layers(args.kicad_pcb, dir2, layers)
-    if bounds2 is None:
-        exit(1)
 
     # Switch back to current version
-    if args.commit != 'HEAD':
-        co(['git', 'checkout', '-'])
+    if args.commit != "HEAD":
+        co(["git", "checkout", "-"])
 
     # Restore local changes
     if do_stash:
-        co(['git', 'stash', 'pop'])
+        co(["git", "stash", "pop"])
 
     # Generate plots into `diffs` directory
     try:
-        mkdir('diffs')
+        mkdir("diffs")
     except OSError:
-        print('diffs directory already exists')
+        print("diffs directory already exists")
 
     # Create a .png diff for each layer
     diff_cntr = 0
     for ll in layers:
         pdf_name = splitext(args.kicad_pcb)[0]
-        pdf_name += '-' + ll.replace('.', '_') + '.pdf'
-        out_file = 'diffs/' + ll + '.png'
+        pdf_name += "-" + ll.replace(".", "_") + ".pdf"
+        out_file = "diffs/" + ll + ".png"
 
-        i1 = load_pdf(join(dir1, pdf_name), r=args.resolution, **bounds1)
-        i2 = load_pdf(join(dir2, pdf_name), r=args.resolution, **bounds1)
+        i1 = load_pdf(join(dir1, pdf_name), r=args.resolution, bounds=bounds1)
+        i2 = load_pdf(join(dir2, pdf_name), r=args.resolution, bounds=bounds1)
         i_out, added, removed = img_diff(i1, i2)
         i_out.save(out_file)
 
-        print('> {:18s} (+{:.6f}, -{:.6f})'.format(out_file, added, removed))
+        print("> {:18s} (+{:.6f}, -{:.6f})".format(out_file, added, removed))
         diff_cntr += added + removed
 
     if diff_cntr == 0:
         print("No visual changes detected")
 
     if not args.keep:
-        print('Removing temporary directories')
+        print("Removing temporary directories")
         rmtree(dir1)
         rmtree(dir2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/kiff/plot_layers.py
+++ b/kiff/plot_layers.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
-'''
+"""
 Plot a selection of layers of a kicad pcb as .pdf files
 
 As of Kicad 8, almost the whole functionality of this script is integrated in
 kicad-cli.
-'''
+"""
 import sys
 import pcbnew
 import os
 
 
-def plot_layers(f_name, plot_dir, layers=['F.Cu', 'B.Cu'], zone_refill=True):
-    '''
+def plot_layers(f_name, plot_dir, layers=["F.Cu", "B.Cu"], zone_refill=True):
+    """
     f_name: the .kicad_pcb file to plot
     plot_dir: output directory for the .pdf files
     layers: list of layer names to plot
     zone_refill: if True, re-calculate copper fills before plotting
     returns: dict with coordinates of bounding box containing the PCB [inches]
-    '''
+    """
     try:
         version = int(pcbnew.Version().split(".")[0])
     except AttributeError:
@@ -34,16 +34,16 @@ def plot_layers(f_name, plot_dir, layers=['F.Cu', 'B.Cu'], zone_refill=True):
     # after this point, chances of failure are low
 
     if zone_refill:
-        print('filling zones ...')
+        print("filling zones ...")
         zf = pcbnew.ZONE_FILLER(board)
         zf.Fill(board.Zones())
 
     boardbox = board.ComputeBoundingBox()
     bounds = {
-        'x': boardbox.GetX() / 1e6 / 25.4,
-        'y': boardbox.GetY() / 1e6 / 25.4,
-        'W': boardbox.GetWidth() / 1e6 / 25.4,
-        'H': boardbox.GetHeight() / 1e6 / 25.4,
+        "x": boardbox.GetX() / 1e6 / 25.4,
+        "y": boardbox.GetY() / 1e6 / 25.4,
+        "W": boardbox.GetWidth() / 1e6 / 25.4,
+        "H": boardbox.GetHeight() / 1e6 / 25.4,
     }
     # print('bounds [inch]:', bounds)
 

--- a/kiff/plot_layers_cli.py
+++ b/kiff/plot_layers_cli.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+import sys
+from subprocess import CalledProcessError, check_output
+
+# global, because we only want to search once for the right cmd
+cmd = ""
+
+
+def find_cmd():
+    global cmd
+    cmd = ["kicad-cli"]
+    version_str = ""
+    for _ in range(2):
+        try:
+            version_str = check_output(cmd + ["-v"])
+        except FileNotFoundError:
+            cmd = ["flatpak", "run", "--command=kicad-cli", "org.kicad.KiCad"]
+
+    if version_str == "":
+        print("Failed to run kicad-cli :(")
+        exit(-1)
+
+    print("found kicad-cli version:", version_str.strip().decode())
+    print("WARNING: automatic zone-refills are not supported (yet)")
+
+
+def plot_layers(f_name, plot_dir, layers=["F.Cu", "B.Cu"], zone_refill=True):
+    """
+    use kicad-cli to create the .pdf plots.
+    Supports native mode and flatpak mode.
+    Not so sure what happens on Windows.
+    """
+    if cmd == "":
+        find_cmd()
+
+    kicad_cli_args = [
+        "pcb",
+        "export",
+        "pdf",
+        "-l",
+        ",".join(layers),
+        "--black-and-white",
+        f_name,
+        "--mode-separate",
+        "-o",
+        plot_dir,
+    ]
+    cmd_full = cmd + kicad_cli_args
+
+    print("$ " + " ".join(cmd_full))
+    check_output(cmd_full)
+
+
+if __name__ == "__main__":
+    boardName = sys.argv[1]
+    plot_dir = sys.argv[2]
+    plot_layers(boardName, plot_dir)

--- a/kiff/plot_layers_cli.py
+++ b/kiff/plot_layers_cli.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 import sys
+from pathlib import Path
 from subprocess import CalledProcessError, check_output
 
 # global, because we only want to search once for the right cmd
-cmd = ""
+cmd = None
+version = None
 
 
 def find_cmd():
-    global cmd
+    global cmd, version
     cmd = ["kicad-cli"]
     version_str = ""
     for _ in range(2):
@@ -20,7 +22,8 @@ def find_cmd():
         print("Failed to run kicad-cli :(")
         exit(-1)
 
-    print("found kicad-cli version:", version_str.strip().decode())
+    version = version_str.strip().decode()
+    print("found kicad-cli version:", version)
     print("WARNING: automatic zone-refills are not supported (yet)")
 
 
@@ -30,25 +33,52 @@ def plot_layers(f_name, plot_dir, layers=["F.Cu", "B.Cu"], zone_refill=True):
     Supports native mode and flatpak mode.
     Not so sure what happens on Windows.
     """
-    if cmd == "":
+    if cmd is None:
         find_cmd()
 
-    kicad_cli_args = [
-        "pcb",
-        "export",
-        "pdf",
-        "-l",
-        ",".join(layers),
-        "--black-and-white",
-        f_name,
-        "--mode-separate",
-        "-o",
-        plot_dir,
-    ]
-    cmd_full = cmd + kicad_cli_args
+    f_name = Path(f_name)
+    plot_dir = Path(plot_dir)
+    plot_dir.mkdir(exist_ok=True)
 
-    print("$ " + " ".join(cmd_full))
-    check_output(cmd_full)
+    if int(version.split(".")[0]) >= 9:
+        # We can plot all the layers in one go with --mode-separate
+        kicad_cli_args = [
+            "pcb",
+            "export",
+            "pdf",
+            "-l",
+            ",".join(layers),
+            "--black-and-white",
+            "--mode-separate",
+            "-o",
+            str(plot_dir),
+            str(f_name),
+        ]
+
+        cmd_full = cmd + kicad_cli_args
+        print("$ " + " ".join(cmd_full))
+        check_output(cmd_full)
+
+    else:
+        # We have to send a plot command for each layer separately
+        for layer in layers:
+            out_name = f_name.stem + "-" + layer.replace(".", "_") + ".pdf"
+
+            kicad_cli_args = [
+                "pcb",
+                "export",
+                "pdf",
+                "-l",
+                layer,
+                "--black-and-white",
+                "-o",
+                str(plot_dir / out_name),
+                str(f_name),
+            ]
+
+            cmd_full = cmd + kicad_cli_args
+            print("$ " + " ".join(cmd_full))
+            check_output(cmd_full)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kiff"
+version = "0.9.0"
+dependencies = ["pillow", "numpy"]
+
+[project.scripts]
+kiff = "kiff.kiff:main"
+
+[tool.black]
+line-length = 120


### PR DESCRIPTION
Add `kicad-cli` support.

Good to have this as the legacy python API will be obsolete soon.

Add CI test for kicad 9.